### PR TITLE
fix: 🐛 修复返回栈中存在搜索页面时重新搜索会跳转到这个页面的bug

### DIFF
--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/search/v2/SearchPanelScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/search/v2/SearchPanelScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cafe.adriel.voyager.navigator.internal.BackHandler
@@ -50,6 +51,9 @@ class SearchPanelScreen(
     private val keyword: List<String> = listOf(),
     private val initialText: String = "",
 ) : Screen {
+    override val key: ScreenKey by lazy {
+        "search_panel_${sort}_${target}_${keyword}_${initialText}"
+    }
     @OptIn(InternalVoyagerApi::class, FlowPreview::class)
     @Composable
     override fun Content() {
@@ -136,7 +140,7 @@ class SearchPanelScreen(
                     else -> {
                         LaunchedEffect(Unit) {
                             model.updateKeywords(listOf())
-                            model.updateText("")
+                            model.updateText(initialText)
                         }
                         TextField(
                             value = state.text,

--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/search/v2/SearchResultScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/search/v2/SearchResultScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import cafe.adriel.voyager.core.annotation.InternalVoyagerApi
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import cafe.adriel.voyager.core.screen.Screen
+import cafe.adriel.voyager.core.screen.ScreenKey
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cafe.adriel.voyager.navigator.internal.BackHandler
@@ -26,6 +27,10 @@ class SearchResultScreen(
     private val sort: SearchSort,
     private val target: SearchTarget,
 ) : Screen {
+    override val key: ScreenKey by lazy {
+        "search_result_${keyword}_${sort}_${target}"
+    }
+
     @OptIn(ExperimentalMaterial3Api::class, InternalVoyagerApi::class)
     @Composable
     override fun Content() {


### PR DESCRIPTION
close #40