### PR TITLE
Use java HttpClient when no need to bypass sni

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -159,6 +159,7 @@ kotlin {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutines.swing)
             implementation(libs.ktor.client.okhttp)
+            implementation(libs.ktor.client.java)
             implementation(libs.androidx.sqlite.bundled)
         }
 

--- a/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/network.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/top/kagg886/pmf/backend/network.desktop.kt
@@ -1,39 +1,49 @@
 package top.kagg886.pmf.backend
 
-import io.ktor.client.*
-import io.ktor.client.engine.*
-import io.ktor.client.engine.okhttp.*
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.java.Java
+import io.ktor.client.engine.java.JavaHttpConfig
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.engine.okhttp.OkHttpConfig
 import java.net.InetSocketAddress
 import java.net.Proxy
+import java.net.http.HttpClient
 import top.kagg886.pmf.util.logger
 
-private val InternalType: HttpClientConfig<OkHttpConfig>.() -> Unit = {
+private val InternalType: HttpClientConfig<HttpClientEngineConfig>.() -> Unit = {
     engine {
-        config {
-            followRedirects(true)
-            when (val config = AppConfig.bypassSettings) {
-                AppConfig.BypassSetting.None -> Unit
-
-                is AppConfig.BypassSetting.SNIReplace -> {
-                    bypassSNIOnDesktop(
-                        queryUrl = config.url,
-                        unsafeSSL = config.nonStrictSSL,
-                        fallback = config.fallback,
-                        dohTimeout = config.dohTimeout,
-                    )
-                }
-
-                is AppConfig.BypassSetting.Proxy -> {
-                    this.proxy(
-                        Proxy(Proxy.Type.valueOf(config.type.toString()), InetSocketAddress.createUnresolved(config.host, config.port)),
-                    )
-                }
+        when (val config = AppConfig.bypassSettings) {
+            AppConfig.BypassSetting.None -> (this as JavaHttpConfig).apply {
+                protocolVersion = HttpClient.Version.HTTP_2
+                config { followRedirects(HttpClient.Redirect.ALWAYS) }
             }
-            logger.i("BypassType: " + AppConfig.bypassSettings::class.simpleName)
+
+            is AppConfig.BypassSetting.SNIReplace -> (this as OkHttpConfig).config {
+                followRedirects(true)
+                bypassSNIOnDesktop(
+                    queryUrl = config.url,
+                    unsafeSSL = config.nonStrictSSL,
+                    fallback = config.fallback,
+                    dohTimeout = config.dohTimeout,
+                )
+            }
+
+            is AppConfig.BypassSetting.Proxy -> (this as JavaHttpConfig).apply {
+                protocolVersion = HttpClient.Version.HTTP_2
+                proxy = Proxy(Proxy.Type.valueOf(config.type.toString()), InetSocketAddress.createUnresolved(config.host, config.port))
+                config { followRedirects(HttpClient.Redirect.ALWAYS) }
+            }
         }
+        logger.i("BypassType: " + AppConfig.bypassSettings::class.simpleName)
     }
 }
 
-actual val PlatformEngine: HttpClientEngineFactory<*> = OkHttp
+actual val PlatformEngine: HttpClientEngineFactory<*> = when (AppConfig.bypassSettings) {
+    AppConfig.BypassSetting.None, is AppConfig.BypassSetting.Proxy -> Java
+    is AppConfig.BypassSetting.SNIReplace -> OkHttp
+}
 
+@Suppress("UNCHECKED_CAST")
 actual val PlatformConfig0: HttpClientConfig<*>.() -> Unit = InternalType as HttpClientConfig<*>.() -> Unit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -57,6 +57,7 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
 ktor-client-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 multiplatform-settings = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
 multiplatform-settings-serialization = { module = "com.russhwolf:multiplatform-settings-serialization", version.ref = "multiplatformSettings" }


### PR DESCRIPTION
HttpClient outperforms Okhttp as it's async & non-blocking