### PR TITLE
Yandex DNS

### DIFF
--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/backend/AppConfig.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/backend/AppConfig.kt
@@ -98,7 +98,7 @@ object AppConfig : Settings by SystemConfig.getConfig("app") {
         @Serializable
         @SerialName("sni-replace")
         data class SNIReplace(
-            val url: String = "https://1.0.0.1/dns-query",
+            val url: String = "https://77.88.8.8/dns-query",
             val fallback: Map<String, List<String>> = mapOf(
                 "app-api.pixiv.net" to listOf("210.140.139.155"),
                 "oauth.secure.pixiv.net" to listOf("210.140.139.155"),


### PR DESCRIPTION
1.0.0.1 was blocked since 1 month after 372196d.

* https://github.com/net4people/bbs/issues/295#issuecomment-2700908050

I changed the default provider to Yandex DNS, based in Russia. It has not yet been blocked by China since [1 year ago](https://github.com/xiaojieonly/Ehviewer_CN_SXJ/commit/99c01f102047a0866830a06eddf2be5ddee2b9f0).

[The Russian blacklist](https://reestr.rublacklist.net/en/?q=pixiv) does have some entries about `pixiv`, but it seems to have no effect on Yandex.