### PR TITLE
移除桌面端分享按钮

### DIFF
--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/download/DownloadScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/download/DownloadScreen.kt
@@ -154,17 +154,19 @@ class DownloadScreen : Screen {
                                             contentDescription = null,
                                         )
                                     }
-                                    IconButton(
-                                        onClick = {
-                                            model.startIllustDownloadOr(item) {
-                                                model.shareFile(item)
-                                            }
-                                        },
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.Share,
-                                            contentDescription = null,
-                                        )
+                                    if (currentPlatform !is Platform.Desktop) {
+                                        IconButton(
+                                            onClick = {
+                                                model.startIllustDownloadOr(item) {
+                                                    model.shareFile(item)
+                                                }
+                                            },
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Share,
+                                                contentDescription = null,
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -232,7 +234,7 @@ class DownloadScreen : Screen {
                                 }
                             }
 
-                            item.progress == -1f && item.success && currentPlatform !is Platform.Desktop -> {
+                            item.progress == -1f && item.success -> {
                                 Row {
                                     IconButton(
                                         onClick = {
@@ -246,17 +248,19 @@ class DownloadScreen : Screen {
                                             contentDescription = null,
                                         )
                                     }
-                                    IconButton(
-                                        onClick = {
-                                            model.startNovelDownloadOr(item) {
-                                                model.shareFile(item)
-                                            }
-                                        },
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Default.Share,
-                                            contentDescription = null,
-                                        )
+                                    if (currentPlatform !is Platform.Desktop) {
+                                        IconButton(
+                                            onClick = {
+                                                model.startNovelDownloadOr(item) {
+                                                    model.shareFile(item)
+                                                }
+                                            },
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Default.Share,
+                                                contentDescription = null,
+                                            )
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
desktop端下载文件夹可见，不需要打开