### PR TITLE
显示原图

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-en/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-en/strings.xml
@@ -365,4 +365,6 @@
     <string name="download_path_not_set">Download path not set, tap here to select</string>
     <string name="download_path_current">Current path: %1$s</string>
     <string name="select_path">Select</string>
+    <string name="show_original_image">Show original image</string>
+    <string name="show_original_image_hint">May slow down network speed. Enable with caution.</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -366,4 +366,6 @@
     <string name="download_path_not_set">未设置下载路径，点击此处选择</string>
     <string name="download_path_current">当前路径: %1$s</string>
     <string name="select_path">选择</string>
+    <string name="show_original_image">显示原图</string>
+    <string name="show_original_image_hint">可能会拖慢网络速度，请谨慎开启</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/backend/AppConfig.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/backend/AppConfig.kt
@@ -39,6 +39,7 @@ object AppConfig : Settings by SystemConfig.getConfig("app") {
 
     var filterAspectRatioType by serializedValue("filter_aspect_ratio", AspectRatioFilterType.NONE)
     var illustDetailsShowAll by boolean("illust_details_show_all", false)
+    var showOriginalImage by boolean("show_original_image", false)
 
     var filterAiNovel by boolean("filter_ai_novel", false)
     var filterR18Novel by boolean("filter_r18_novel", false)

--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/detail/illust/IllustDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/detail/illust/IllustDetailScreen.kt
@@ -59,9 +59,12 @@ import cafe.adriel.voyager.koin.koinScreenModel
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import cafe.adriel.voyager.navigator.internal.BackHandler
+import coil3.EventListener
 import coil3.compose.AsyncImagePainter.State
+import coil3.compose.LocalPlatformContext
 import coil3.compose.SubcomposeAsyncImage
 import coil3.compose.SubcomposeAsyncImageContent
+import coil3.request.ImageRequest
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -90,6 +93,7 @@ import top.kagg886.pmf.no_description
 import top.kagg886.pmf.openBrowser
 import top.kagg886.pmf.open_in_browser
 import top.kagg886.pmf.publish_date
+import top.kagg886.pmf.show_original_image
 import top.kagg886.pmf.tags
 import top.kagg886.pmf.ui.component.ErrorPage
 import top.kagg886.pmf.ui.component.FavoriteButton
@@ -208,7 +212,7 @@ class IllustDetailScreen(illust: SerializableWrapper<Illust>) : Screen, KoinComp
     }
 
     @Composable
-    private fun IllustTopAppBar(illust: Illust) {
+    private fun IllustTopAppBar(illust: Illust, onOriginImageRequest: () -> Unit = {}) {
         val nav = LocalNavigator.currentOrThrow
         TopAppBar(
             title = { Text(text = stringResource(Res.string.image_details)) },
@@ -236,6 +240,11 @@ class IllustDetailScreen(illust: SerializableWrapper<Illust>) : Screen, KoinComp
                             enabled = false
                         },
                     )
+
+                    DropdownMenuItem(
+                        text = { Text(stringResource(Res.string.show_original_image)) },
+                        onClick = onOriginImageRequest,
+                    )
                 }
             },
         )
@@ -248,7 +257,9 @@ class IllustDetailScreen(illust: SerializableWrapper<Illust>) : Screen, KoinComp
     ) {
         Scaffold(
             topBar = {
-                IllustTopAppBar(state.illust)
+                IllustTopAppBar(state.illust) {
+                    model.toggleOrigin()
+                }
             },
         ) {
             Row(modifier = Modifier.fillMaxSize().padding(it)) {
@@ -287,7 +298,9 @@ class IllustDetailScreen(illust: SerializableWrapper<Illust>) : Screen, KoinComp
         ) {
             Scaffold(
                 topBar = {
-                    IllustTopAppBar(state.illust)
+                    IllustTopAppBar(state.illust) {
+                        model.toggleOrigin()
+                    }
                 },
             ) {
                 Row(modifier = Modifier.fillMaxSize().padding(it)) {
@@ -323,7 +336,7 @@ class IllustDetailScreen(illust: SerializableWrapper<Illust>) : Screen, KoinComp
             }
 
             var expand by remember { mutableStateOf(AppConfig.illustDetailsShowAll) }
-            val img by remember(illust.hashCode(), expand) {
+            val img by remember(state.data.sumOf { it.hashCode() }, expand) {
                 mutableStateOf(state.data.let { if (!expand) it.take(3) else it })
             }
             LazyColumn(
@@ -345,7 +358,7 @@ class IllustDetailScreen(illust: SerializableWrapper<Illust>) : Screen, KoinComp
                         contentDescription = null,
                     ) {
                         val state by painter.state.collectAsState()
-                        when (state) {
+                        when (val s = state) {
                             is State.Success -> SubcomposeAsyncImageContent(
                                 modifier = Modifier.clickable {
                                     startIndex = i
@@ -353,12 +366,20 @@ class IllustDetailScreen(illust: SerializableWrapper<Illust>) : Screen, KoinComp
                                 },
                             )
 
-                            else -> Box(
+                            is State.Loading -> Box(
                                 modifier = Modifier.align(Alignment.Center),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 CircularProgressIndicator()
                             }
+
+                            is State.Error -> ErrorPage(
+                                modifier = Modifier.align(Alignment.Center),
+                                text = s.result.throwable.message ?: "Unknown Error",
+                                onClick = { model.load() },
+                            )
+
+                            else -> Unit
                         }
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/setting/SettingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/top/kagg886/pmf/ui/route/main/setting/SettingScreen.kt
@@ -176,6 +176,8 @@ import top.kagg886.pmf.settings_download_path
 import top.kagg886.pmf.settings_download_path_desc
 import top.kagg886.pmf.settings_download_path_not_supported
 import top.kagg886.pmf.shareFile
+import top.kagg886.pmf.show_original_image
+import top.kagg886.pmf.show_original_image_hint
 import top.kagg886.pmf.show_toast_when_failed
 import top.kagg886.pmf.show_toast_when_latest
 import top.kagg886.pmf.single_column_width
@@ -559,6 +561,17 @@ class SettingScreen : Screen {
                     state = illustDetailsShowAll,
                     title = { Text(stringResource(Res.string.illust_details_show_all)) },
                     onCheckedChange = { illustDetailsShowAll = it },
+                )
+
+                var showOriginalImage by remember { mutableStateOf(AppConfig.showOriginalImage) }
+                LaunchedEffect(showOriginalImage) {
+                    AppConfig.showOriginalImage = showOriginalImage
+                }
+                SettingsSwitch(
+                    state = showOriginalImage,
+                    title = { Text(stringResource(Res.string.show_original_image)) },
+                    subtitle = { Text(stringResource(Res.string.show_original_image_hint)) },
+                    onCheckedChange = { showOriginalImage = it },
                 )
             }
             SettingsGroup(title = { Text(stringResource(Res.string.novel_settings)) }) {


### PR DESCRIPTION
1. 设置页面提供 显示原图的开关，开启后无论什么图片都会展示原图
2. 在右上角菜单添加原图显示
3. close #148